### PR TITLE
feat: add EMI and ae2 unfocus support

### DIFF
--- a/src/main/java/fr/oxodao/fixescape/ClientEventHandler.java
+++ b/src/main/java/fr/oxodao/fixescape/ClientEventHandler.java
@@ -9,6 +9,10 @@ import net.neoforged.neoforge.client.event.ScreenEvent;
 public class ClientEventHandler {
     private static boolean IS_KEY_PRESSED = false;
 
+    public static void omitNextEscape() {
+        ClientEventHandler.IS_KEY_PRESSED = true;
+    }
+
     @SubscribeEvent
     public void onScreenKeyPressed(ScreenEvent.KeyPressed.Post evt) {
         if (ClientEventHandler.IS_KEY_PRESSED) {

--- a/src/main/java/fr/oxodao/fixescape/mixin/AETextFieldMixin.java
+++ b/src/main/java/fr/oxodao/fixescape/mixin/AETextFieldMixin.java
@@ -1,0 +1,28 @@
+package fr.oxodao.fixescape.mixin;
+
+import fr.oxodao.fixescape.ClientEventHandler;
+import fr.oxodao.fixescape.ClientModEvents;
+import net.minecraft.client.gui.components.EditBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Mixin to unfocus EMI search bar when pressing the new escape key.
+ */
+@Mixin(targets = "appeng.client.gui.widgets.AETextField")
+public class AETextFieldMixin {
+
+    @Inject(method = "keyPressed", at = @At("HEAD"))
+    public void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!((EditBox) (Object) this).isFocused() ||
+                keyCode != ClientModEvents.NEW_ESCAPE.get().getKey().getValue()) {
+            return;
+        }
+
+        ((EditBox) (Object) this).setFocused(false);
+        ClientEventHandler.omitNextEscape();
+    }
+
+}

--- a/src/main/java/fr/oxodao/fixescape/mixin/CreativeSearchMixin.java
+++ b/src/main/java/fr/oxodao/fixescape/mixin/CreativeSearchMixin.java
@@ -10,15 +10,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(CreativeModeInventoryScreen.class)
 public class CreativeSearchMixin {
-    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "keyPressed", at = @At("HEAD"))
     public void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
         if (keyCode == ClientModEvents.NEW_ESCAPE.get().getKey().getValue()) {
             Minecraft mc = Minecraft.getInstance();
             if (mc.screen != null && mc.screen.shouldCloseOnEsc()) {
                 mc.screen.onClose();
             }
-
-            cir.setReturnValue(true);
         }
     }
 }

--- a/src/main/java/fr/oxodao/fixescape/mixin/EmiSearchWidgetMixin.java
+++ b/src/main/java/fr/oxodao/fixescape/mixin/EmiSearchWidgetMixin.java
@@ -1,0 +1,30 @@
+package fr.oxodao.fixescape.mixin;
+
+import fr.oxodao.fixescape.ClientEventHandler;
+import fr.oxodao.fixescape.ClientModEvents;
+import net.minecraft.client.gui.components.EditBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Mixin to unfocus EMI search bar when pressing the new escape key.
+ */
+@Mixin(targets = "dev.emi.emi.screen.widget.EmiSearchWidget")
+public class EmiSearchWidgetMixin {
+
+    @Inject(method = "keyPressed", at = @At("HEAD"))
+    public void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!((EditBox) (Object) this).isFocused() ||
+                keyCode != ClientModEvents.NEW_ESCAPE.get().getKey().getValue()) {
+            return;
+        }
+
+        ((EditBox) (Object) this).setFocused(false);
+        ClientEventHandler.omitNextEscape();
+
+        cir.setReturnValue(true);
+    }
+
+}

--- a/src/main/resources/fixescape.mixins.json
+++ b/src/main/resources/fixescape.mixins.json
@@ -3,7 +3,7 @@
   "package": "fr.oxodao.fixescape.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [],
-  "client": ["CreativeSearchMixin", "EmiSearchWidgetMixin"],
+  "client": ["CreativeSearchMixin", "EmiSearchWidgetMixin", "AETextFieldMixin"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/fixescape.mixins.json
+++ b/src/main/resources/fixescape.mixins.json
@@ -3,9 +3,7 @@
   "package": "fr.oxodao.fixescape.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [],
-  "client": [
-    "CreativeSearchMixin"
-  ],
+  "client": ["CreativeSearchMixin", "EmiSearchWidgetMixin"],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
This add unfocusing support for ae2 and emi search bars.
The mod still works without ae2 or emi.