### PR TITLE
fix(EMI): fix crash when unfocusing search while looking at a recipe

### DIFF
--- a/src/main/java/fr/oxodao/fixescape/mixin/EmiSearchWidgetMixin.java
+++ b/src/main/java/fr/oxodao/fixescape/mixin/EmiSearchWidgetMixin.java
@@ -23,8 +23,6 @@ public class EmiSearchWidgetMixin {
 
         ((EditBox) (Object) this).setFocused(false);
         ClientEventHandler.omitNextEscape();
-
-        cir.setReturnValue(true);
     }
 
 }


### PR DESCRIPTION
I unfortunately removed the `cri.setReturnValue` on the wrong file. This didn't hurt but it also didn't fix the crash I experienced.
I am sorry.